### PR TITLE
バージョン番号に先頭 0 が含まれる場合には形式エラーとする様に修正。

### DIFF
--- a/lib/semantic_versioning/version.rb
+++ b/lib/semantic_versioning/version.rb
@@ -2,7 +2,7 @@ module SemanticVersioning
   VERSION = '0.0.1'.freeze
 
   class Version
-    SEMVER = /\A(\d+\.\d+\.\d+)\Z/.freeze
+    SEMVER = /\A((\d|[1-9]\d+)\.(\d|[1-9][\d]+)\.(\d|[1-9][\d]+))\Z/.freeze
     LABEL = [:major, :minor, :patch].freeze
 
     attr_reader :major, :minor, :patch, :incremental_label

--- a/spec/semantic_versioning/version_spec.rb
+++ b/spec/semantic_versioning/version_spec.rb
@@ -24,7 +24,10 @@ describe SemanticVersioning::Version do
         'a.b.c',
         '1.2.a',
         '1.b.3',
-        'c.2.3'
+        'c.2.3',
+        '0.0.01',
+        '0.02.1',
+        '03.2.1'
       ].each do |v|
         it "#{v} is not a valid Semantic Versioning string." do
           expect do


### PR DESCRIPTION
#12 fixed bug.
